### PR TITLE
Implement changing tags

### DIFF
--- a/src/components/courses/Courses.less
+++ b/src/components/courses/Courses.less
@@ -51,6 +51,11 @@
 	flex-direction: column;
 	width: 67%;
 	white-space: pre-line;
+
+	.labels {
+		display: flex;
+		flex-direction: column;
+	}
 }
 
 .meta-details {

--- a/src/components/courses/LabelSelector.tsx
+++ b/src/components/courses/LabelSelector.tsx
@@ -1,0 +1,43 @@
+import { CourseCategory, CourseTag } from '../../types/Course';
+import { Select } from 'antd';
+import React from 'react';
+
+const { Option } = Select;
+
+export default function LabelSelector({
+  category,
+  tags,
+  setTags,
+  tagProposals,
+}: {
+  category: CourseCategory;
+  tags: CourseTag[];
+  setTags(tags: CourseTag[]): void;
+  tagProposals: CourseTag[];
+}) {
+  const handleChange = (value: string[]) => {
+    setTags(
+      value.map(
+        (n) =>
+          tagProposals
+            .filter((t) => t.category === category)
+            .find((t) => t.identifier === n) ?? { name: n }
+      )
+    );
+  };
+
+  return (
+    <Select
+      mode="tags"
+      value={tags.map((t) => t.identifier ?? t.name ?? '')}
+      onChange={handleChange}
+      style={{ width: '100%' }}
+    >
+      {tagProposals
+        .filter((t) => t.category === category)
+        .map((t) => (
+          <Option value={t.identifier ?? t.name ?? ''}>{t.name ?? ''}</Option>
+        ))}
+    </Select>
+  );
+}

--- a/src/types/Course.ts
+++ b/src/types/Course.ts
@@ -26,6 +26,7 @@ export interface ApiCourseUpdate {
   description?: string;
   outline?: string;
   category?: CourseCategory;
+  tags?: { name?: string; identifier?: string }[];
   imageUrl?: string | null;
   screeningComment?: string | null;
   instructors?: { id: number }[];
@@ -48,10 +49,10 @@ export enum CourseCategory {
 }
 
 export interface CourseTag {
-  id: number;
-  identifier: string;
-  name: string;
-  category: string;
+  id?: number;
+  identifier?: string;
+  name?: string;
+  category?: string;
 }
 
 export interface Subcourse {


### PR DESCRIPTION
This PR enables editing course tags. Either previously used tags fetched from the backend can be used or new tags can be created. The relation between category and tags is taken into account: On changing the category, the tags are reset (after confirmation) and only those tags which belong to the selected category will be proposed.
This PR depends on PR [#152](https://github.com/corona-school/backend/pull/152) in the backend and PR [#28](https://github.com/corona-school/backend-screening/pull/28) in the screening backend.