### PR TITLE
Reset pagination when navigating the page

### DIFF
--- a/src/components/courses/Courses.tsx
+++ b/src/components/courses/Courses.tsx
@@ -89,6 +89,11 @@ const Courses = () => {
     loadCourseTags();
   }, [courseState, search, page]);
 
+  /* When switching tabs or searching, start with page 0 again */
+  useEffect(() => {
+    setPage(0);
+  }, [courseState, search]);
+
   return (
     <div className="course-container">
       {editCourse && (


### PR DESCRIPTION
Otherwise confusing effects appear, like a search finding "nothing" (as one is on the second page).